### PR TITLE
Switch to using yaml.safe_load instead of yaml.load

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(readme_path, encoding='utf-8') as file:
 
 setup(
     name='yamole',
-    version='2.1.6',
+    version='2.1.7',
     description='A YAML parser that resolves JSON references',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test.py
+++ b/tests/test.py
@@ -15,7 +15,7 @@ with open(os.path.join(TEST_DIR, 'source.yaml')) as file:
     actual = parser.data
 
 with open(os.path.join(TEST_DIR, 'expected.yaml')) as file:
-    expected = yaml.load(file)
+    expected = yaml.safe_load(file)
 
 assert(actual == expected)
 

--- a/yamole.py
+++ b/yamole.py
@@ -33,7 +33,7 @@ class YamoleParser():
 
     def __init__(self, file, openapi_mode=True, merge_allof=None,
                  max_depth=1000):
-        self.data = yaml.load(file)
+        self.data = yaml.safe_load(file)
         # merge_allof is a deprecated flag from when "openapi_mode" only did
         # that. Keeping it to keep retrocompatibility.
         self.openapi_mode = merge_allof or openapi_mode
@@ -123,7 +123,7 @@ class YamoleParser():
                             ref_src = self.cache[uri]
                         else:
                             with open(uri, 'r') as file:
-                                ref_src = yaml.load(file)
+                                ref_src = yaml.safe_load(file)
                             self.cache[uri] = ref_src
                     else:
                         ref_src = parent


### PR DESCRIPTION
Using yaml.load without specifying the loader to use, has been deprecated.
https://msg.pyyaml.org/load has more information on the deprecation. This
commit switches to using the `safe_load` shortcut which uses the `SafeLoader`.

